### PR TITLE
systemd: Set RemainAfterExit=yes for oneshot service

### DIFF
--- a/scripts/lvm2_activation_generator_systemd_red_hat.c
+++ b/scripts/lvm2_activation_generator_systemd_red_hat.c
@@ -160,7 +160,7 @@ static int generate_unit(struct generator *gen, int unit)
 	fputs("ExecStart=" LVM_PATH " vgchange -aay", f);
 	if (gen->cfg.sysinit_needed)
 		fputs(" --sysinit", f);
-	fputs("\nType=oneshot\n", f);
+	fputs("\nType=oneshot\nRemainAfterExit=yes\n", f);
 
 	if (fclose(f) < 0) {
 		_error("Failed to write unit file %s: %m.\n", unit_name);


### PR DESCRIPTION
The lvm2-activation(-early).service was triggered multiple times which
if done too quickly leads to a failure like this:
  systemd[1]: Finished Activation of LVM2 logical volumes.
  systemd[1]: lvm2-activation-early.service: Start request repeated too quickly.
  systemd[1]: lvm2-activation-early.service: Failed with result 'start-limit-hit'.
Set RemainAfterExit=yes as done for the other oneshot services to
prevent the unit from running multiple times in a row and hitting the
restart limit.

(Patch was sent as mail to lvm-devel@redhat.com)