### PR TITLE
pvscan: wait for udevd

### DIFF
--- a/scripts/lvm2-pvscan.service.in
+++ b/scripts/lvm2-pvscan.service.in
@@ -4,6 +4,7 @@ Documentation=man:pvscan(8)
 DefaultDependencies=no
 StartLimitIntervalSec=0
 BindsTo=dev-block-%i.device
+After=systemd-udevd.service
 Before=shutdown.target
 Conflicts=shutdown.target
 


### PR DESCRIPTION
Running the scan before udevd finished startup may result in failure.
This has been reported for Arch Linux [0] and proper ordering fixes
the issue.

[0] https://bugs.archlinux.org/task/69611

Signed-off-by: Christian Hesse <mail@eworm.de>