### PR TITLE
lvmdbusd: Add a new 'Shared' property to the Vg interface

### DIFF
--- a/daemons/lvmdbusd/vg.py
+++ b/daemons/lvmdbusd/vg.py
@@ -151,6 +151,7 @@ class Vg(AutomatedProperties):
 	_AllocNormal_meta = ('b', VG_INTERFACE)
 	_AllocAnywhere_meta = ('b', VG_INTERFACE)
 	_Clustered_meta = ('b', VG_INTERFACE)
+	_Shared_meta = ('b', VG_INTERFACE)
 	_Name_meta = ('s', VG_INTERFACE)
 
 	# noinspection PyUnusedLocal,PyPep8Naming
@@ -784,6 +785,10 @@ class Vg(AutomatedProperties):
 	@property
 	def Clustered(self):
 		return self._attribute(5, 'c')
+
+	@property
+	def Shared(self):
+		return self._attribute(5, 's')
 
 
 class VgVdo(Vg):


### PR DESCRIPTION
@tasleson can you please look at this. We now have a request for a simple support for shared VGs for GFS2 so we might need this property in the future for libblockdev/blivet.