### PR TITLE
Update the py-compile script (works with Python 3.12)

### DIFF
--- a/autoconf/py-compile
+++ b/autoconf/py-compile
@@ -1,9 +1,9 @@
 #!/bin/sh
 # py-compile - Compile a Python program
 
-scriptversion=2011-06-08.12; # UTC
+scriptversion=2023-03-30.00; # UTC
 
-# Copyright (C) 2000-2014 Free Software Foundation, Inc.
+# Copyright (C) 2000-2023 Free Software Foundation, Inc.
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,7 +16,7 @@ scriptversion=2011-06-08.12; # UTC
 # GNU General Public License for more details.
 
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # As a special exception to the GNU General Public License, if you
 # distribute this file as part of a program that contains a
@@ -27,7 +27,7 @@ scriptversion=2011-06-08.12; # UTC
 # bugs to <bug-automake@gnu.org> or send patches to
 # <automake-patches@gnu.org>.
 
-if [ -z "$PYTHON" ]; then
+if test -z "$PYTHON"; then
   PYTHON=python
 fi
 
@@ -62,12 +62,18 @@ while test $# -ne 0; do
       ;;
     -h|--help)
       cat <<\EOF
-Usage: py-compile [--help] [--version] [--basedir DIR] [--destdir DIR] FILES..."
+Usage: py-compile [options] FILES...
 
 Byte compile some python scripts FILES.  Use --destdir to specify any
 leading directory path to the FILES that you don't want to include in the
 byte compiled file.  Specify --basedir for any additional path information you
 do want to be shown in the byte compiled file.
+
+Options:
+  --basedir DIR   Prefix all FILES with DIR, and include in error messages.
+  --destdir DIR   Prefix all FILES with DIR before compiling.
+  -v, --version   Display version information.
+  -h, --help      This help screen.
 
 Example:
   py-compile --destdir /tmp/pkg-root --basedir /usr/share/test test.py test2.py
@@ -94,77 +100,143 @@ EOF
   shift
 done
 
-files=$*
-if test -z "$files"; then
-    usage_error "no files given"
+if test $# -eq 0; then
+  usage_error "no files given"
 fi
 
 # if basedir was given, then it should be prepended to filenames before
 # byte compilation.
-if [ -z "$basedir" ]; then
-    pathtrans="path = file"
+if test -z "$basedir"; then
+  pathtrans="path = file"
 else
-    pathtrans="path = os.path.join('$basedir', file)"
+  pathtrans="path = os.path.join('$basedir', file)"
 fi
 
 # if destdir was given, then it needs to be prepended to the filename to
 # byte compile but not go into the compiled file.
-if [ -z "$destdir" ]; then
-    filetrans="filepath = path"
+if test -z "$destdir"; then
+  filetrans="filepath = path"
 else
-    filetrans="filepath = os.path.normpath('$destdir' + os.sep + path)"
+  filetrans="filepath = os.path.normpath('$destdir' + os.sep + path)"
 fi
 
-$PYTHON -c "
-import sys, os, py_compile, imp
+python_major=`$PYTHON -c 'import sys; print(sys.version_info[0])'`
+if test -z "$python_major"; then
+  usage_error "could not determine $PYTHON major version"
+fi
 
-files = '''$files'''
+case $python_major in
+[01])
+  usage_error "python version 0.x and 1.x not supported"
+  ;;
+esac
+
+python_minor=`$PYTHON -c 'import sys; print(sys.version_info[1])'`
+
+# NB: When adding support for newer versions, prefer copying & adding new cases
+# rather than try to keep things merged with shell variables.
+
+# First byte compile (no optimization) all the modules.
+# This works for all currently known Python versions.
+$PYTHON -c "
+import sys, os, py_compile
+
+try:
+    import importlib
+except ImportError:
+    importlib = None
+
+# importlib.util.cache_from_source was added in 3.4
+if (
+        hasattr(importlib, 'util')
+        and hasattr(importlib.util, 'cache_from_source')
+):
+    destpath = importlib.util.cache_from_source
+else:
+    destpath = lambda filepath: filepath + 'c'
 
 sys.stdout.write('Byte-compiling python modules...\n')
-for file in files.split():
+for file in sys.argv[1:]:
     $pathtrans
     $filetrans
-    if not os.path.exists(filepath) or not (len(filepath) >= 3
-                                            and filepath[-3:] == '.py'):
-	    continue
-    sys.stdout.write(file)
+    if (
+            not os.path.exists(filepath)
+            or not (len(filepath) >= 3 and filepath[-3:] == '.py')
+     ):
+        continue
+    sys.stdout.write(file + ' ')
     sys.stdout.flush()
-    if hasattr(imp, 'get_tag'):
-        py_compile.compile(filepath, imp.cache_from_source(filepath), path)
-    else:
-        py_compile.compile(filepath, filepath + 'c', path)
-sys.stdout.write('\n')" || exit $?
+    py_compile.compile(filepath, destpath(filepath), path)
+sys.stdout.write('\n')" "$@" || exit $?
 
-# this will fail for python < 1.5, but that doesn't matter ...
+# Then byte compile w/optimization all the modules.
 $PYTHON -O -c "
-import sys, os, py_compile, imp
+import sys, os, py_compile
 
-# pypy does not use .pyo optimization
-if hasattr(sys, 'pypy_translation_info'):
+try:
+    import importlib
+except ImportError:
+    importlib = None
+
+# importlib.util.cache_from_source was added in 3.4
+if (
+        hasattr(importlib, 'util')
+        and hasattr(importlib.util, 'cache_from_source')
+):
+    destpath = importlib.util.cache_from_source
+else:
+    destpath = lambda filepath: filepath + 'o'
+
+# pypy2 does not use .pyo optimization
+if sys.version_info.major <= 2 and hasattr(sys, 'pypy_translation_info'):
     sys.exit(0)
 
-files = '''$files'''
 sys.stdout.write('Byte-compiling python modules (optimized versions) ...\n')
-for file in files.split():
+for file in sys.argv[1:]:
     $pathtrans
     $filetrans
-    if not os.path.exists(filepath) or not (len(filepath) >= 3
-                                            and filepath[-3:] == '.py'):
-	    continue
-    sys.stdout.write(file)
+    if (
+            not os.path.exists(filepath)
+            or not (len(filepath) >= 3 and filepath[-3:] == '.py')
+    ):
+        continue
+    sys.stdout.write(file + ' ')
     sys.stdout.flush()
-    if hasattr(imp, 'get_tag'):
-        py_compile.compile(filepath, imp.cache_from_source(filepath, False), path)
-    else:
-        py_compile.compile(filepath, filepath + 'o', path)
-sys.stdout.write('\n')" 2>/dev/null || :
+    py_compile.compile(filepath, destpath(filepath), path)
+sys.stdout.write('\n')" "$@" 2>/dev/null || exit $?
+
+# Then byte compile w/more optimization.
+# Only do this for Python 3.5+, see https://bugs.gnu.org/38043 for background.
+case $python_major.$python_minor in
+2.*|3.[0-4])
+  ;;
+*)
+  $PYTHON -OO -c "
+import sys, os, py_compile, importlib
+
+sys.stdout.write('Byte-compiling python modules (more optimized versions)'
+                 ' ...\n')
+for file in sys.argv[1:]:
+    $pathtrans
+    $filetrans
+    if (
+            not os.path.exists(filepath)
+            or not (len(filepath) >= 3 and filepath[-3:] == '.py')
+    ):
+        continue
+    sys.stdout.write(file + ' ')
+    sys.stdout.flush()
+    py_compile.compile(filepath, importlib.util.cache_from_source(filepath), path)
+sys.stdout.write('\n')" "$@" 2>/dev/null || exit $?
+  ;;
+esac
 
 # Local Variables:
 # mode: shell-script
 # sh-indentation: 2
-# eval: (add-hook 'write-file-hooks 'time-stamp)
+# eval: (add-hook 'before-save-hook 'time-stamp)
 # time-stamp-start: "scriptversion="
 # time-stamp-format: "%:y-%02m-%02d.%02H"
-# time-stamp-time-zone: "UTC"
+# time-stamp-time-zone: "UTC0"
 # time-stamp-end: "; # UTC"
 # End:


### PR DESCRIPTION
The version of automake's py-compile that lvm2 carries around in autoconf/ is ancient. Particularly, it assumes the 'imp' module exists, which as of Python 3.12 is no longer a safe assumption. This just updates lvm2's copy of the file to the latest version in upstream automake -
https://raw.githubusercontent.com/autotools-mirror/automake/4bd4640e03670e267d9763d377f107c09b4f2202/lib/py-compile . From a quick look at the changes, the interface shouldn't have changed, this should just work better with modern Python.