### PR TITLE
tests: fix wrong pos in transform if CONFIG_PRINTK_CALLER is on

### DIFF
--- a/test/lib/brick-shelltest.h
+++ b/test/lib/brick-shelltest.h
@@ -717,9 +717,17 @@ struct KMsg : Source {
         unsigned long t;
         time_t tt;
         size_t len;
+        char *delimiter;
 
         buf[ *sz ] = 0;
-        if (sscanf( buf, "%u,%u,%lu,-;%n", &level, &num, &t, &pos ) == 3) {
+
+        delimiter = strchr( buf, ';' );
+        if ( !delimiter )
+            return;
+        pos = delimiter - buf + 1;
+        delimiter = 0;
+
+        if (sscanf( buf, "%u,%u,%lu,-", &level, &num, &t) == 3) {
             memcpy( newbuf, buf, *sz );
             tt = time( 0 );
             len = snprintf( buf, 64, "[%lu.%06lu] <%u> ", t / 1000000, t % 1000000, level );


### PR DESCRIPTION
kernels of SUSE distributions enable CONFIG_PRINTK_CALLER by default. One line of cat /dev/kmsg is like:

6,904,9506214456,-,caller=T24012;loop8: detected capacity change from 0 to 354304

If CONFIG_PRINTK_CALLER is off:

6,721,53563833,-;loop0: detected capacity change from 0 to 354304

',caller=T24012' is the redundant part needed to be handled. Otherwise pos will be lager than buf size causing sz underflowed.

Fix it by using ';' as delimiter to get pos.