### PR TITLE
devices: do not create directory of devices file unconditionally

### DIFF
--- a/lib/device/dev-cache.c
+++ b/lib/device/dev-cache.c
@@ -2000,8 +2000,6 @@ int setup_devices_file(struct cmd_context *cmd)
 {
 	char dirpath[PATH_MAX];
 	const char *filename = NULL;
-	struct stat st;
-	int rv;
 
 	/* Use dmeventd.devices if it exists. */
 	if (cmd->run_by_dmeventd && _setup_devices_file_dmeventd(cmd))
@@ -2046,18 +2044,6 @@ int setup_devices_file(struct cmd_context *cmd)
 		return 0;
 	}
 
-	if (stat(dirpath, &st)) {
-		log_debug("Creating %s.", dirpath);
-		dm_prepare_selinux_context(dirpath, S_IFDIR);
-		rv = mkdir(dirpath, 0755);
-		dm_prepare_selinux_context(NULL, 0);
-
-		if ((rv < 0) && stat(dirpath, &st)) {
-			log_error("Failed to create %s %d", dirpath, errno);
-			return 0;
-		}
-	}
-	
 	if (dm_snprintf(cmd->devices_file_path, sizeof(cmd->devices_file_path),
 			"%s/devices/%s", cmd->system_dir, filename) < 0) {
 		log_error("Failed to copy devices file path");


### PR DESCRIPTION
Our openQA recently reported lvm2-monitor.service fails to start since system.devices is enabled[1]. The cause is that lvm2-monitor.service, `lvm vgchange --monitor y` always tries to create /etc/lvm/devices/ even /etc/ is not ready to be written, journal_check-full_journal.log:

Aug 04 14:42:49.238243 localhost systemd[1]: Starting Monitoring of LVM2 mirrors, snapshots etc. using dmeventd or progress polling... ...
Aug 04 14:42:49.249029 localhost lvm[1013]:   Failed to create
/etc/lvm/devices 2
Aug 04 14:42:49.249029 localhost lvm[1013]:   Failed to set up devices.
...
Aug 04 14:42:49.255674 localhost kernel: BTRFS info (device vda3 state
M): enabling auto defrag
Aug 04 14:42:49.255685 localhost kernel: BTRFS info (device vda3 state
M): use lzo compression, level 0
...


NOTE: this issue could happen on not only btrfs, but also other fses on slow matchines. It could be more frequent if /etc is a mountpoint which means a larger delay after sysroot.

Before this commit, if system.devices is enabled, every command which calls setup_devices_file() always creates /etc/lvm/devices/ unconditionally. However, not all of devices dir creations are necessary. We only need to create the directory before devices file creation.

Link: https://bugzilla.suse.com/show_bug.cgi?id=1228854