### PR TITLE
vgreduce: enable --select option with --removemissing

### DIFF
--- a/tools/command-lines.in
+++ b/tools/command-lines.in
@@ -1943,8 +1943,8 @@ OO: OO_VGREDUCE
 ID: vgreduce_all
 DESC: Remove all unused PVs from a VG.
 
-vgreduce --removemissing VG
-OO: --mirrorsonly, OO_VGREDUCE
+vgreduce --removemissing VG|Select
+OO: --mirrorsonly, OO_VGREDUCE, --select String
 ID: vgreduce_missing
 DESC: Remove all missing PVs from a VG.
 

--- a/tools/commands.h
+++ b/tools/commands.h
@@ -229,7 +229,7 @@ xx(vgmknodes,
 
 xx(vgreduce,
    "Remove physical volume(s) from a volume group",
-   0)
+   ALL_VGS_IS_DEFAULT)
 
 xx(vgremove,
    "Remove volume group(s)",

--- a/tools/vgreduce.c
+++ b/tools/vgreduce.c
@@ -176,7 +176,7 @@ int vgreduce(struct cmd_context *cmd, int argc, char **argv)
 {
 	struct processing_handle *handle;
 	struct vgreduce_params vp = { 0 };
-	const char *vg_name;
+	const char *vg_name = NULL;
 	int repairing = arg_is_set(cmd, removemissing_ARG);
 	int saved_ignore_suspended_devices = ignore_suspended_devices();
 	int ret;
@@ -187,7 +187,7 @@ int vgreduce(struct cmd_context *cmd, int argc, char **argv)
 		return EINVALID_CMD_LINE;
 	}
 	
-	if (!argc) { /* repairing */
+	if (!argc && !arg_is_set(cmd, select_ARG)) { /* repairing */
 		log_error("Please give volume group name.");
 		return EINVALID_CMD_LINE;
 	}
@@ -213,9 +213,12 @@ int vgreduce(struct cmd_context *cmd, int argc, char **argv)
 		return EINVALID_CMD_LINE;
 	}
 
-	vg_name = skip_dev_dir(cmd, argv[0], NULL);
-	argv++;
-	argc--;
+	if (argc)
+	{
+		vg_name = skip_dev_dir(cmd, argv[0], NULL);
+		argv++;
+		argc--;
+	}
 
 	if (!lock_global(cmd, "ex"))
 		return_ECMD_FAILED;


### PR DESCRIPTION
Calling `vgreduce` with `--removemissing` option results in an error if there is more than one volume group with the passed name. The error message suggests using volume group UUID in place of the name; however, there is no way to do so.

This allows passing volume group UUID via `--select` option.

Similar to [patch](https://sourceware.org/git/?p=lvm2.git;a=commit;h=81f10c1d1e844dd3ad9918a31a0d7c00fed36c94) mentioned in [issue](https://github.com/lvmteam/lvm2/issues/93)